### PR TITLE
Blog app - integration specs for views and fix n+1 problems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.0.2'
+ruby '~> 3.0'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.4', '>= 7.0.4.3'

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem 'web-console'
+  gem 'bullet'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile
+++ b/Gemfile
@@ -57,8 +57,8 @@ end
 
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
-  gem 'web-console'
   gem 'bullet'
+  gem 'web-console'
 
   # Add speed badges [https://github.com/MiniProfiler/rack-mini-profiler]
   # gem "rack-mini-profiler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,9 @@ GEM
     bootsnap (1.16.0)
       msgpack (~> 1.2)
     builder (3.2.4)
+    bullet (7.0.7)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.38.0)
       addressable
       matrix
@@ -235,6 +238,7 @@ GEM
     tzinfo-data (1.2023.3)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.4.2)
+    uniform_notifier (1.16.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -258,6 +262,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootsnap
+  bullet
   capybara
   debug
   importmap-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,12 +249,9 @@ GEM
     tzinfo-data (1.2023.3)
       tzinfo (>= 1.0.0)
     unicode-display_width (2.4.2)
-<<<<<<< HEAD
     uniform_notifier (1.16.0)
-=======
     warden (1.2.9)
       rack (>= 2.0.9)
->>>>>>> dev
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,12 +128,15 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.14.2-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
     pg (1.4.6)
+    pg (1.4.6-x64-mingw-ucrt)
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -229,6 +232,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2023.3)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.4.2)
     web-console (4.2.0)
       actionview (>= 6.0.0)
@@ -248,6 +253,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -22,9 +22,9 @@
     </div>
   </div>
   <div class = "post-comments">
-    <% @post.comments.each do |comment| %>
+    <% @post.comments.includes(:author).each do |comment| %>
     <li>
-      <%= User.find(comment.author_id).name%>:
+      <%= comment.author.name%>:
       <%= comment.text %>
       <% end %>
     </li>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # In the development environment your application's code is reloaded any time

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require "bullet"
 
 # The test environment is used exclusively to run your application's
 # test suite. You never need to work with it otherwise. Remember that
@@ -6,6 +7,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = true # raise an error if n+1 query occurs
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PostsController, type: :request do
 
     it 'displays the correct heading' do
       get '/users/1/posts'
-      expect(response.body).to include('Posts')
+      expect(response.body).to include('Tanjiro Kamado')
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe PostsController, type: :request do
 
     it 'displays the correct heading' do
       get '/users/1/posts/1'
-      expect(response.body).to include('Post')
+      expect(response.body).to include('This battle was agains my own sister that was converted to demon')
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe UsersController, type: :request do
 
     it 'displays the correct heading' do
       get '/users'
-      expect(response.body).to include('Users')
+      expect(response.body).to include('Tanjiro Kamado')
     end
   end
 
@@ -31,7 +31,7 @@ RSpec.describe UsersController, type: :request do
 
     it 'displays the correct heading' do
       get '/users/1'
-      expect(response.body).to include('User')
+      expect(response.body).to include('Tanjiro Kamado')
     end
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -2,13 +2,20 @@ require 'rails_helper'
 
 RSpec.describe 'posts/index.html.erb', type: :feature do
   before(:each) do
-    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg', bio: 'Friendly guy that leaves as a demon slayer.')
-    @post = Post.create(author: @user, title: 'My first post', text: 'This battle was agains my own sister that was converted to demon')
-    @post2 = Post.create(author: @user, title: 'My second post', text: 'This battle was agains my own sister that was converted to demon')
-    @post3 = Post.create(author: @user, title: 'My third post', text: 'This battle was agains my own sister that was converted to demon')
-    @comment = Comment.create(author: @user, post: @post, text: 'Lorem ipsum', user_id: @user.id, author_id: @user.id, author_type: 'user')
-    @comment2 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum2', user_id: @user.id, author_id: @user.id, author_type: 'user')
-    @comment3 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum3', user_id: @user.id, author_id: @user.id, author_type: 'user')
+    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg',
+                        bio: 'Friendly guy that leaves as a demon slayer.')
+    @post = Post.create(author: @user, title: 'My first post',
+                        text: 'This battle was agains my own sister that was converted to demon')
+    @post2 = Post.create(author: @user, title: 'My second post',
+                         text: 'This battle was agains my own sister that was converted to demon')
+    @post3 = Post.create(author: @user, title: 'My third post',
+                         text: 'This battle was agains my own sister that was converted to demon')
+    @comment = Comment.create(author: @user, post: @post, text: 'Lorem ipsum', user_id: @user.id, author_id: @user.id,
+                              author_type: 'user')
+    @comment2 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum2', user_id: @user.id,
+                               author_id: @user.id, author_type: 'user')
+    @comment3 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum3', user_id: @user.id,
+                               author_id: @user.id, author_type: 'user')
     @like = Like.create(user: @user, post: @post)
     @like2 = Like.create(user: @user, post: @post)
     visit user_posts_path(@user.id)
@@ -57,8 +64,8 @@ RSpec.describe 'posts/index.html.erb', type: :feature do
   end
 
   it 'redirects me to a specif post' do
-    link = find("a[href='#{user_post_path(@post.author, @post)}']")
+    link = find("a[href='#{user_post_path(@user, @post)}']")
     link.click
-    expect(page).to have_current_path(user_post_path(@post.author, @post))
+    expect(page).to have_current_path(user_post_path(@user, @post))
   end
 end

--- a/spec/features/post_index_spec.rb
+++ b/spec/features/post_index_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe 'posts/index.html.erb', type: :feature do
+  before(:each) do
+    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg', bio: 'Friendly guy that leaves as a demon slayer.')
+    @post = Post.create(author: @user, title: 'My first post', text: 'This battle was agains my own sister that was converted to demon')
+    @post2 = Post.create(author: @user, title: 'My second post', text: 'This battle was agains my own sister that was converted to demon')
+    @post3 = Post.create(author: @user, title: 'My third post', text: 'This battle was agains my own sister that was converted to demon')
+    @comment = Comment.create(author: @user, post: @post, text: 'Lorem ipsum', user_id: @user.id, author_id: @user.id, author_type: 'user')
+    @comment2 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum2', user_id: @user.id, author_id: @user.id, author_type: 'user')
+    @comment3 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum3', user_id: @user.id, author_id: @user.id, author_type: 'user')
+    @like = Like.create(user: @user, post: @post)
+    @like2 = Like.create(user: @user, post: @post)
+    visit user_posts_path(@user.id)
+  end
+
+  it 'Shows the profile picture' do
+    expect(page).to have_selector("img[src*='#{@user.photo}']")
+  end
+
+  it 'Shows the username' do
+    expect(page).to have_content(@user.name)
+  end
+
+  it 'shows the number of posts each user has written' do
+    expect(page).to have_content("Number of post: #{@user.posts.count}")
+  end
+
+  it 'Shows the titles' do
+    expect(page).to have_content(@post.title)
+    expect(page).to have_content(@post2.title)
+    expect(page).to have_content(@post3.title)
+  end
+
+  it 'Shows the content' do
+    expect(page).to have_content(@post.text)
+    expect(page).to have_content(@post2.text)
+    expect(page).to have_content(@post3.text)
+  end
+
+  it 'Shows the comments' do
+    expect(page).to have_content(@comment.text)
+    expect(page).to have_content(@comment2.text)
+    expect(page).to have_content(@comment3.text)
+  end
+
+  it 'shows the number of comments on each post' do
+    expect(page).to have_content("Comments: #{@post.comments.count}")
+  end
+
+  it 'shows the number of likes on each post' do
+    expect(page).to have_content("Likes: #{@post.likes.count}")
+  end
+
+  it 'shows a button for pagination' do
+    expect(page).to have_content('Pagination')
+  end
+
+  it 'redirects me to a specif post' do
+    link = find("a[href='#{user_post_path(@post.author, @post)}']")
+    link.click
+    expect(page).to have_current_path(user_post_path(@post.author, @post))
+  end
+end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe 'posts/show.html.erb', type: :feature do
+  before(:each) do
+    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg', bio: 'Friendly guy that leaves as a demon slayer.')
+    @post = Post.create(author: @user, title: 'My first post', text: 'This battle was agains my own sister that was converted to demon')
+    @comment = Comment.create(author: @user, post: @post, text: 'Lorem ipsum', user_id: @user.id, author_id: @user.id, author_type: 'user')
+    @comment2 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum2', user_id: @user.id, author_id: @user.id, author_type: 'user')
+    @comment3 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum3', user_id: @user.id, author_id: @user.id, author_type: 'user')
+    @like = Like.create(user: @user, post: @post)
+    @like2 = Like.create(user: @user, post: @post)
+    visit user_post_path(@user, @post)
+  end
+
+  it 'Shows the title' do
+    expect(page).to have_content(@post.title)
+  end
+
+  it 'Shows the name of the author' do
+    expect(page).to have_content(@post.author.name)
+  end
+
+  it 'shows the number of comments on each post' do
+    expect(page).to have_content("Comments: #{@post.comments.count}")
+  end
+
+  it 'shows the number of likes on each post' do
+    expect(page).to have_content("Likes: #{@post.likes.count}")
+  end
+
+  it 'Shows the body of the post' do
+    expect(page).to have_content(@post.text)
+  end
+
+  it 'Shows the name of the commenter' do
+    expect(page).to have_content(@comment.author.name)
+  end
+
+  it 'Shows the body of the comment' do
+    expect(page).to have_content(@comment.text)
+  end
+end

--- a/spec/features/post_show_spec.rb
+++ b/spec/features/post_show_spec.rb
@@ -2,11 +2,16 @@ require 'rails_helper'
 
 RSpec.describe 'posts/show.html.erb', type: :feature do
   before(:each) do
-    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg', bio: 'Friendly guy that leaves as a demon slayer.')
-    @post = Post.create(author: @user, title: 'My first post', text: 'This battle was agains my own sister that was converted to demon')
-    @comment = Comment.create(author: @user, post: @post, text: 'Lorem ipsum', user_id: @user.id, author_id: @user.id, author_type: 'user')
-    @comment2 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum2', user_id: @user.id, author_id: @user.id, author_type: 'user')
-    @comment3 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum3', user_id: @user.id, author_id: @user.id, author_type: 'user')
+    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg',
+                        bio: 'Friendly guy that leaves as a demon slayer.')
+    @post = Post.create(author: @user, title: 'My first post',
+                        text: 'This battle was agains my own sister that was converted to demon')
+    @comment = Comment.create(author: @user, post: @post, text: 'Lorem ipsum', user_id: @user.id, author_id: @user.id,
+                              author_type: 'user')
+    @comment2 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum2', user_id: @user.id,
+                               author_id: @user.id, author_type: 'user')
+    @comment3 = Comment.create(author: @user, post: @post, text: 'Lorem ipsum3', user_id: @user.id,
+                               author_id: @user.id, author_type: 'user')
     @like = Like.create(user: @user, post: @post)
     @like2 = Like.create(user: @user, post: @post)
     visit user_post_path(@user, @post)

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'users/index.html.erb', type: :feature do
+  before(:each) do
+    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg', bio: 'Friendly guy that leaves as a demon slayer.')
+    @user2 = User.create(name: 'Nezuko Kamado', photo: 'https://static.zerochan.net/Kamado.Nezuko.full.2843321.jpg', bio: 'Tanjiro\'s younger sister who turns into a demon.')
+    visit users_path
+  end
+
+  it 'shows the name of all the users' do
+    expect(page).to have_content(@user.name)
+    expect(page).to have_content(@user2.name)
+  end
+
+  it 'shows the profile picture of each user' do
+    expect(page).to have_selector("img[src*='#{@user.photo}']")
+    expect(page).to have_selector("img[src*='#{@user2.photo}']")
+  end
+
+  it 'shows the number of posts each user has written' do
+    expect(page).to have_content("Number of post: #{@user.posts.count}")
+    expect(page).to have_content("Number of post: #{@user2.posts.count}")
+  end
+
+  it 'redirects me to that users page' do
+    link = find("a[href='#{user_path(@user)}']")
+    link.click
+    expect(page).to have_current_path(user_path(@user))
+  end
+end

--- a/spec/features/user_index_spec.rb
+++ b/spec/features/user_index_spec.rb
@@ -2,8 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'users/index.html.erb', type: :feature do
   before(:each) do
-    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg', bio: 'Friendly guy that leaves as a demon slayer.')
-    @user2 = User.create(name: 'Nezuko Kamado', photo: 'https://static.zerochan.net/Kamado.Nezuko.full.2843321.jpg', bio: 'Tanjiro\'s younger sister who turns into a demon.')
+    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg',
+                        bio: 'Friendly guy that leaves as a demon slayer.')
+    @user2 = User.create(name: 'Nezuko Kamado', photo: 'https://static.zerochan.net/Kamado.Nezuko.full.2843321.jpg',
+                         bio: 'Tanjiro\'s younger sister who turns into a demon.')
     visit users_path
   end
 

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -2,12 +2,17 @@ require 'rails_helper'
 
 RSpec.describe 'users/show.html.erb', type: :feature do
   before(:each) do
-    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg', bio: 'Friendly guy that leaves as a demon slayer.')
-    @post = Post.create(author: @user, title: 'My first post', text: 'This battle was agains my own sister that was converted to demon')
-    @post2 = Post.create(author: @user, title: 'My second post', text: 'This battle was agains my own sister that was converted to demon')
-    @post3 = Post.create(author: @user, title: 'My third post', text: 'This battle was agains my own sister that was converted to demon')
-    @comment = Comment.create(author: @user, post: @post, text: 'Lorem ipsum', user_id: @user.id, author_id: @user.id, author_type: 'user')
-    @like2 = Like.create(user: @user, post: @post)
+    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg',
+                        bio: 'Friendly guy that leaves as a demon slayer.')
+    @post = Post.create(author: @user, title: 'My first post', text: 'no view')
+    @post2 = Post.create(author: @user, title: 'My second post',
+                         text: 'This battle was agains my own sister that was converted to demon')
+    @post3 = Post.create(author: @user, title: 'My third post',
+                         text: 'This battle was agains my own sister that was converted to demon')
+    @post4 = Post.create(author: @user, title: 'My third post',
+                         text: 'This battle was agains my own sister that was converted to demon')
+    @comment = Comment.create(author: @user, post: @post, text: 'Lorem ipsum', user_id: @user.id, author_id: @user.id,
+                              author_type: 'user')
     visit user_path(@user)
   end
 
@@ -28,9 +33,10 @@ RSpec.describe 'users/show.html.erb', type: :feature do
   end
 
   it 'shows the first 3 posts' do
-    expect(page).to have_content(@post.text)
     expect(page).to have_content(@post2.text)
     expect(page).to have_content(@post3.text)
+    expect(page).to have_content(@post4.text)
+    expect(page).to_not have_content(@post.text)
   end
 
   it 'shows the all posts button' do

--- a/spec/features/user_show_spec.rb
+++ b/spec/features/user_show_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe 'users/show.html.erb', type: :feature do
+  before(:each) do
+    @user = User.create(name: 'Tanjiro Kamado', photo: 'https://static.zerochan.net/Kamado.Tanjirou.full.2705519.jpg', bio: 'Friendly guy that leaves as a demon slayer.')
+    @post = Post.create(author: @user, title: 'My first post', text: 'This battle was agains my own sister that was converted to demon')
+    @post2 = Post.create(author: @user, title: 'My second post', text: 'This battle was agains my own sister that was converted to demon')
+    @post3 = Post.create(author: @user, title: 'My third post', text: 'This battle was agains my own sister that was converted to demon')
+    @comment = Comment.create(author: @user, post: @post, text: 'Lorem ipsum', user_id: @user.id, author_id: @user.id, author_type: 'user')
+    @like2 = Like.create(user: @user, post: @post)
+    visit user_path(@user)
+  end
+
+  it 'Shows the profile picture' do
+    expect(page).to have_selector("img[src*='#{@user.photo}']")
+  end
+
+  it 'Shows the username' do
+    expect(page).to have_content(@user.name)
+  end
+
+  it 'shows the number of posts each user has written' do
+    expect(page).to have_content("Number of post: #{@user.posts.count}")
+  end
+
+  it 'shows the bio' do
+    expect(page).to have_content(@user.bio)
+  end
+
+  it 'shows the first 3 posts' do
+    expect(page).to have_content(@post.text)
+    expect(page).to have_content(@post2.text)
+    expect(page).to have_content(@post3.text)
+  end
+
+  it 'shows the all posts button' do
+    expect(page).to have_content('See all posts')
+  end
+
+  it 'redirects to form post' do
+    link = find("a[href='#{new_user_post_path(@user)}']")
+    link.click
+    expect(page).to have_current_path(new_user_post_path(@user))
+  end
+
+  it 'redirects me to all posts' do
+    link = find("a[href='#{user_posts_path(@user)}']")
+    link.click
+    expect(page).to have_current_path(user_posts_path(@user))
+  end
+end

--- a/spec/requests/posts_spec.rb
+++ b/spec/requests/posts_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe 'Posts', type: :request do
-  describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,7 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe 'Users', type: :request do
-  describe 'GET /index' do
-    pending "add some examples (or delete) #{__FILE__}"
-  end
-end


### PR DESCRIPTION
# In this pull request, We were able to: 

- Make sure that the N+1 problem is solved when fetching all posts and their comments for a user, I don't have any N+1 problems, and I also use bullet gem in order to corroborate this. 

- Use Capybara to write integration tests for each view in your project.

## User index page:
Can see the username of all other users.
Can see the profile picture for each user.
Can see the number of posts each user has written.
When I click on a user, I am redirected to that user's show page.

## User show page:
Can see the user's profile picture.
Can see the user's username.
Can see the number of posts the user has written.
Can see the user's bio.
Can see the user's first 3 posts.
Can see a button that lets me view all of a user's posts.
When I click a user's post, it redirects me to that post's show page.
When I click to see all posts, it redirects me to the user's post's index page.

##User post index page:
Can see the user's profile picture.
Can see the user's username.
Can see the number of posts the user has written.
Can see a post's title.
Can see some of the post's body.
Can see the first comments on a post.
Can see how many comments a post has.
Can see how many likes a post has.
Can see a section for pagination if there are more posts than fit on the view.
When I click on a post, it redirects me to that post's show page.

##Post show page:
Can see the post's title.
Can see who wrote the post.
Can see how many comments it has.
Can see how many likes it has.
Can see the post body.
Can see the username of each commentor.
Can see the comment each commentor left.

Thanks for the revision
Diego