### PR TITLE
Blog app: add API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,12 @@ You can deploy this project using:
 
 [![portfolio](https://img.shields.io/badge/my_portfolio-000?style=for-the-badge&logo=ko-fi&logoColor=white)](https://github.com/dgcuenca) [![linkedin](https://img.shields.io/badge/dgcuenca-0A66C2?style=for-the-badge&logo=linkedin&logoColor=white)](https://linkedin.com/in/dgcuenca)
 
+ **Paul Sáenz Sucre**
+
+- GitHub: [@paulsaenzsucre](https://github.com/paulsaenzsucre)
+- Twitter: [@paulsaenzsucre](https://twitter.com/paulsaenzsucre)
+- LinkedIn: [@paulsaenzsucre](https://www.linkedin.com/in/paulsaenzsucre
+
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- FUTURE FEATURES -->

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,0 +1,6 @@
+class Api::CommentsController < ApplicationController
+  def index
+    @post = Post.find(request.params['post_id'])
+    render :json => @post.comments.all
+  end
+end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -3,7 +3,7 @@ class Api::CommentsController < ApplicationController
 
   def index
     @post = Post.find(request.params['post_id'])
-    render :json => @post.comments.all
+    render json: @post.comments.all
   end
 
   def create
@@ -17,9 +17,9 @@ class Api::CommentsController < ApplicationController
     @comment.user_id = @user.id
     @comment.author_type = 'User'
     if @comment.save
-      render :json => {"status": 'Siuuuuuuuuuuuu'}
+      render json: { status: 'Siuuuuuuuuuuuu' }
     else
-      render :json => {"status": 'Nou'}
+      render json: { status: 'Nou' }
     end
   end
 end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,4 +1,6 @@
 class Api::CommentsController < ApplicationController
+  protect_from_forgery with: :null_session
+
   def index
     @post = Post.find(request.params['post_id'])
     render :json => @post.comments.all
@@ -10,7 +12,7 @@ class Api::CommentsController < ApplicationController
 
     @user = User.find(comment_params[:user_id])
     @post = Post.find(comment_params[:post_id])
-    @comment = @post.comments.create(comment_params[:text])
+    @comment = @post.comments.create(comment_params)
     @comment.author = @user
     @comment.user_id = @user.id
     @comment.author_type = 'User'

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -3,4 +3,21 @@ class Api::CommentsController < ApplicationController
     @post = Post.find(request.params['post_id'])
     render :json => @post.comments.all
   end
+
+  def create
+    comment_params = params.require(:comment).permit(:user_id, :post_id, :text)
+    # Aquí puedes usar los valores de name y email
+
+    @user = User.find(comment_params[:user_id])
+    @post = Post.find(comment_params[:post_id])
+    @comment = @post.comments.create(comment_params[:text])
+    @comment.author = @user
+    @comment.user_id = @user.id
+    @comment.author_type = 'User'
+    if @comment.save
+      render :json => {"status": 'Siuuuuuuuuuuuu'}
+    else
+      render :json => {"status": 'Nou'}
+    end
+  end
 end

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,0 +1,6 @@
+class Api::PostsController < ApplicationController
+    def index
+        @user = User.find(request.params['user_id'])
+        render :json => @user.posts.all
+    end
+end

--- a/app/controllers/api/posts_controller.rb
+++ b/app/controllers/api/posts_controller.rb
@@ -1,6 +1,6 @@
 class Api::PostsController < ApplicationController
-    def index
-        @user = User.find(request.params['user_id'])
-        render :json => @user.posts.all
-    end
+  def index
+    @user = User.find(request.params['user_id'])
+    render json: @user.posts.all
+  end
 end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,0 +1,3 @@
+class ApiController < ApplicationController
+    
+end

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,3 +1,2 @@
 class ApiController < ApplicationController
-    
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
+  
   # Renders the default view for the index action.
   def index
     @users = User.all

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   before_action :authenticate_user!
-  
+
   # Renders the default view for the index action.
   def index
     @users = User.all

--- a/app/helpers/api/posts_helper.rb
+++ b/app/helpers/api/posts_helper.rb
@@ -1,0 +1,2 @@
+module Api::PostsHelper
+end

--- a/app/helpers/api/users/posts_helper.rb
+++ b/app/helpers/api/users/posts_helper.rb
@@ -1,0 +1,2 @@
+module Api::Users::PostsHelper
+end

--- a/app/helpers/api/users_helper.rb
+++ b/app/helpers/api/users_helper.rb
@@ -1,0 +1,2 @@
+module Api::UsersHelper
+end

--- a/app/helpers/api_helper.rb
+++ b/app/helpers/api_helper.rb
@@ -1,0 +1,2 @@
+module ApiHelper
+end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,10 +6,10 @@ class Comment < ApplicationRecord
 
   def update_post_comments_counter
     post.update(comments_counter: post.comments.count)
-  end  
+  end
 
   # Option 2: Working with the default #as_json method
-  def as_json(options={})
-   super({ only: [:text, :author_id, :post_id] }.merge(options))
- end
+  def as_json(options = {})
+    super({ only: %i[text author_id post_id] }.merge(options))
+  end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,5 +6,10 @@ class Comment < ApplicationRecord
 
   def update_post_comments_counter
     post.update(comments_counter: post.comments.count)
-  end
+  end  
+
+  # Option 2: Working with the default #as_json method
+  def as_json(options={})
+   super({ only: [:text, :author_id, :post_id] }.merge(options))
+ end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -16,4 +16,10 @@ class Post < ApplicationRecord
   def recent_comments
     comments.order(created_at: :desc).limit(5)
   end
+
+   # Option 2: Working with the default #as_json method
+   def as_json(options={})
+    super({ only: [:title, :text] }.merge(options))
+  end
+
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,9 +17,8 @@ class Post < ApplicationRecord
     comments.order(created_at: :desc).limit(5)
   end
 
-   # Option 2: Working with the default #as_json method
-   def as_json(options={})
-    super({ only: [:title, :text] }.merge(options))
+  # Option 2: Working with the default #as_json method
+  def as_json(options = {})
+    super({ only: %i[title text] }.merge(options))
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,5 +21,4 @@ class User < ApplicationRecord
   def present?
     role == 'user'
   end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,4 +21,5 @@ class User < ApplicationRecord
   def present?
     role == 'user'
   end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,12 +12,9 @@ root "users#index"
     end
   end
   
-  resources :api do
+  namespace :api do
     resources :users do
-      resources :posts do
-        resources :comments
-      end
+      resources :posts
     end
   end
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,4 +12,12 @@ root "users#index"
     end
   end
   
+  resources :api do
+    resources :users do
+      resources :posts do
+        resources :comments
+      end
+    end
+  end
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,9 @@ root "users#index"
   
   namespace :api do
     resources :users do
-      resources :posts
+      resources :posts do
+        resources :comments
+      end
     end
   end
 end

--- a/spec/helpers/api/posts_helper_spec.rb
+++ b/spec/helpers/api/posts_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::PostsHelper. For example:
+#
+# describe Api::PostsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::PostsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/api/users/posts_helper_spec.rb
+++ b/spec/helpers/api/users/posts_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::Users::PostsHelper. For example:
+#
+# describe Api::Users::PostsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::Users::PostsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/api/users_helper_spec.rb
+++ b/spec/helpers/api/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the Api::UsersHelper. For example:
+#
+# describe Api::UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe Api::UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/api_helper_spec.rb
+++ b/spec/helpers/api_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the ApiHelper. For example:
+#
+# describe ApiHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe ApiHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Posts", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/posts_spec.rb
+++ b/spec/requests/api/posts_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Api::Posts", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::Posts', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/requests/api/users/posts_spec.rb
+++ b/spec/requests/api/users/posts_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Users::Posts", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/users/posts_spec.rb
+++ b/spec/requests/api/users/posts_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Api::Users::Posts", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::Users::Posts', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::Users", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/users_spec.rb
+++ b/spec/requests/api/users_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Api::Users", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Api::Users', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Apis", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe "Apis", type: :request do
-  describe "GET /index" do
+RSpec.describe 'Apis', type: :request do
+  describe 'GET /index' do
     pending "add some examples (or delete) #{__FILE__}"
   end
 end


### PR DESCRIPTION
In this pull request, We were able to: 

- Create an API endpoint to list all posts for a user. 
  endpoint(http://127.0.0.1:3000/api/users/1/posts)
- Create an API endpoint to list all comments for a user's post.
  endpoint(http://localhost:3000/api/users/1/posts/2/comments/)
- Create an API endpoint to add a comment to a post. 
 endpoint(localhost:3000/api/users/1/posts/1/comments)
 example format: {"user_id": 1,"post_id": 1,"text": "This is the first comment with API"}

Thanks for the revision
Diego